### PR TITLE
Add basic Swing GUI structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,4 +48,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version> <!-- Use a recent version -->
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.audiomania.gui.MainApp</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/com/audiomania/gui/MainApp.java
+++ b/src/main/java/com/audiomania/gui/MainApp.java
@@ -1,0 +1,23 @@
+package com.audiomania.gui;
+
+import javax.swing.*;
+import java.awt.EventQueue;
+import java.awt.BorderLayout; // Import BorderLayout
+
+public class MainApp {
+
+    public static void main(String[] args) {
+        EventQueue.invokeLater(() -> {
+            JFrame frame = new JFrame("AudioMania");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.setSize(400, 300);
+
+            JLabel label = new JLabel("Hello Swing!", SwingConstants.CENTER);
+            frame.getContentPane().add(label, BorderLayout.CENTER); // Add label to the content pane
+
+            frame.setLocationRelativeTo(null); // Center the window
+            frame.setVisible(true);
+            System.out.println("Swing JFrame with a JLabel should be visible now.");
+        });
+    }
+}

--- a/src/main/java/com/audiomania/gui/package-info.java
+++ b/src/main/java/com/audiomania/gui/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains the GUI classes for the AudioMania application using Swing.
+ */
+package com.audiomania.gui;


### PR DESCRIPTION
This commit introduces Java Swing for the application's user interface.

Key changes:
- Created a new package `com.audiomania.gui` for all GUI-related classes.
- Added `MainApp.java` within this package, which serves as the entry point for the Swing application.
- Set up a basic `JFrame` in `MainApp` to act as the main application window.
- Included a `JLabel` in the `JFrame` as an initial component.
- Updated `pom.xml` to specify `com.audiomania.gui.MainApp` as the main class for executable JAR packaging, using `maven-jar-plugin`.

This provides the foundational structure for building out the Swing-based GUI for AudioMania.